### PR TITLE
Fix issue with 12 PM conversion to a 24-hour clock

### DIFF
--- a/src/InternalDate.elm
+++ b/src/InternalDate.elm
@@ -74,5 +74,8 @@ toHour ampm hour =
         ( AM, _ ) ->
             hour
 
+        ( PM, 12 ) ->
+            12
+
         ( PM, _ ) ->
             hour + 12


### PR DESCRIPTION
Hey,

I noticed this issue while using your [date time picker](https://github.com/abadi199/datetimepicker).

It would try to parse "12:xx PM" and return 24 as an hour, which the Date.Extra package would then turn into a "23:xx", making it impossible for the user to select any time between 12PM and 13PM (not included)

Cheers!